### PR TITLE
[Serde generate] runtimes: negative fuzzing + UTF8 validation + max container depth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ jobs:
           command: |
             cargo build --all-targets
             cargo test
-            cargo build --all-targets --all-features
-            cargo test --all-features
+            cargo build --release --all-targets --all-features
+            cargo test --release --all-features
 
   # docs-build and docs-deploy are adapted from
   # https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,30 +50,12 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "block-buffer"
-version = "0.7.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0940dc441f31689269e10ac70eb1002a3a1d3ad1390e030043662eb7fe4688b"
+checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
 dependencies = [
- "block-padding",
- "byte-tools",
- "byteorder",
  "generic-array",
 ]
-
-[[package]]
-name = "block-padding"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa79dedbb091f449f1f39e53edf88d5dbe95f895dae6135a8d7b881fb5af73f5"
-dependencies = [
- "byte-tools",
-]
-
-[[package]]
-name = "byte-tools"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b5ca7a04898ad4bcd41c90c5285445ff5b791899bb1b0abdd2a2aa791211d7"
 
 [[package]]
 name = "byteorder"
@@ -83,18 +65,18 @@ checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
 
 [[package]]
 name = "bytes"
-version = "0.5.4"
+version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "130aac562c0dd69c56b3b1cc8ffd2e17be31d0b6c25b61c96b76231aa23e39e1"
+checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.54"
+version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bbb73db36c1246e9034e307d0fba23f9a2e251faa47ade70c1bd252220c8311"
+checksum = "ef611cc68ff783f18535d77ddd080185275713d852c4f5cbb6122c462a7a825c"
 dependencies = [
  "jobserver",
 ]
@@ -121,10 +103,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.8.1"
+name = "cpuid-bool"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
+checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
+
+[[package]]
+name = "digest"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
 ]
@@ -136,12 +124,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4358a9e11b9a09cf52383b451b49a169e8d797b68aa02301ff586d70d9661ea3"
 
 [[package]]
-name = "fake-simd"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
-
-[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,11 +131,12 @@ checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
 
 [[package]]
 name = "generic-array"
-version = "0.12.3"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c68f0274ae0e023facc3c97b2e00f076be70e254bc851d972503b328db79b2ec"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
 dependencies = [
  "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -260,7 +243,7 @@ checksum = "99e85c08494b21a9054e7fe1374a732aeadaff3980b6990b94bfd3a70f690005"
 [[package]]
 name = "libra-canonical-serialization"
 version = "0.1.0"
-source = "git+https://github.com/libra/libra.git?branch=testnet#58882b9c03b0d31d4749b18571ef25057ae33dea"
+source = "git+https://github.com/libra/libra.git?branch=auto#1362572498cfb1d72b49e01c56caecbbba854ee1"
 dependencies = [
  "libra-workspace-hack",
  "serde",
@@ -270,7 +253,7 @@ dependencies = [
 [[package]]
 name = "libra-workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/libra/libra.git?branch=testnet#58882b9c03b0d31d4749b18571ef25057ae33dea"
+source = "git+https://github.com/libra/libra.git?branch=auto#1362572498cfb1d72b49e01c56caecbbba854ee1"
 dependencies = [
  "bytes",
  "cc",
@@ -292,9 +275,9 @@ checksum = "ae91b68aebc4ddb91978b11a1b02ddd8602a05ec19002801c5666000e05e0f83"
 
 [[package]]
 name = "log"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
+checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
 dependencies = [
  "cfg-if",
  "serde",
@@ -323,9 +306,9 @@ dependencies = [
 
 [[package]]
 name = "opaque-debug"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2839e79665f131bdb5782e51f2c6c9599c133c6098982a54c794358bf432529c"
+checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "petgraph"
@@ -457,9 +440,9 @@ checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
 
 [[package]]
 name = "serde"
-version = "1.0.112"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736aac72d1eafe8e5962d1d1c3d99b0df526015ba40915cb3c49d042e92ec243"
+checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
 dependencies = [
  "serde_derive",
 ]
@@ -516,9 +499,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.112"
+version = "1.0.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0343ce212ac0d3d6afd9391ac8e9c9efe06b533c8d33f660f6390cc4093f57"
+checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -550,13 +533,14 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7d94d0bede923b3cea61f3f1ff57ff8cdfd77b400fb8f9998949e0cf04163df"
+checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
 dependencies = [
  "block-buffer",
+ "cfg-if",
+ "cpuid-bool",
  "digest",
- "fake-simd",
  "opaque-debug",
 ]
 
@@ -592,15 +576,15 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.2.3"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "502d53007c02d7605a05df1c1a73ee436952781653da5d0bf57ad608f66932c1"
+checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
-version = "1.0.31"
+version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5304cfdf27365b7585c25d4af91b35016ed21ef88f17ced89c7093b43dba8b6"
+checksum = "6690e3e9f692504b941dc6c3b188fd28df054f7fb8469ab40680df52fdcc842b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,9 +34,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "bincode"
-version = "1.2.1"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5753e2a71534719bf3f4e57006c3a4f0d2c672a4b676eec84161f763eca87dbf"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
 dependencies = [
  "byteorder",
  "serde",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -30,11 +30,11 @@ textwrap = "0.12.1"
 
 serde-reflection = { path = "../serde-reflection", version = "0.3.0" }
 
-bincode = { version = "1.2", optional = true }
+bincode = { version = "1.3.1", optional = true }
 libra-canonical-serialization = { git = "https://github.com/libra/libra.git", branch = "testnet", optional = true }
 
 [dev-dependencies]
-bincode = { version = "1.2" }
+bincode = { version = "1.3.1" }
 tempfile = "3.1"
 hex = "0.4.2"
 which = "4.0.2"

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -22,7 +22,7 @@ runtime-testing = ["libra-canonical-serialization", "bincode"]
 heck = "0.3.1"
 include_dir = "0.6"
 maplit = "1.0.2"
-serde = { version = "1.0.112", features = ["derive"] }
+serde = { version = "1.0.116", features = ["derive"] }
 serde_bytes = "0.11.3"
 serde_yaml = "0.8"
 structopt = "0.3.12"
@@ -31,7 +31,7 @@ textwrap = "0.12.1"
 serde-reflection = { path = "../serde-reflection", version = "0.3.0" }
 
 bincode = { version = "1.3.1", optional = true }
-libra-canonical-serialization = { git = "https://github.com/libra/libra.git", branch = "testnet", optional = true }
+libra-canonical-serialization = { git = "https://github.com/libra/libra.git", branch = "auto", optional = true }
 
 [dev-dependencies]
 bincode = { version = "1.3.1" }

--- a/serde-generate/runtime/cpp/bincode.hpp
+++ b/serde-generate/runtime/cpp/bincode.hpp
@@ -3,6 +3,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "serde.hpp"
 #include "binary.hpp"
 
@@ -15,7 +17,7 @@ class BincodeSerializer : public BinarySerializer<BincodeSerializer> {
     using Parent = BinarySerializer<BincodeSerializer>;
 
   public:
-    BincodeSerializer() : Parent() {}
+    BincodeSerializer() : Parent(SIZE_MAX) {}
 
     void serialize_len(size_t value);
     void serialize_variant_index(uint32_t value);
@@ -28,7 +30,7 @@ class BincodeDeserializer : public BinaryDeserializer<BincodeDeserializer> {
 
   public:
     BincodeDeserializer(std::vector<uint8_t> bytes)
-        : Parent(std::move(bytes)) {}
+        : Parent(std::move(bytes), SIZE_MAX) {}
 
     size_t deserialize_len();
     uint32_t deserialize_variant_index();

--- a/serde-generate/runtime/cpp/lcs.hpp
+++ b/serde-generate/runtime/cpp/lcs.hpp
@@ -14,6 +14,7 @@ namespace serde {
 
 // Maximum length supported for LCS sequences and maps.
 constexpr size_t LCS_MAX_LENGTH = (1ull << 31) - 1;
+constexpr size_t LCS_MAX_CONTAINER_DEPTH = 500;
 
 class LcsSerializer : public BinarySerializer<LcsSerializer> {
     using Parent = BinarySerializer<LcsSerializer>;
@@ -21,7 +22,7 @@ class LcsSerializer : public BinarySerializer<LcsSerializer> {
     void serialize_u32_as_uleb128(uint32_t);
 
   public:
-    LcsSerializer() : Parent() {}
+    LcsSerializer() : Parent(LCS_MAX_CONTAINER_DEPTH) {}
 
     void serialize_len(size_t value);
     void serialize_variant_index(uint32_t value);
@@ -36,7 +37,8 @@ class LcsDeserializer : public BinaryDeserializer<LcsDeserializer> {
     uint32_t deserialize_uleb128_as_u32();
 
   public:
-    LcsDeserializer(std::vector<uint8_t> bytes) : Parent(std::move(bytes)) {}
+    LcsDeserializer(std::vector<uint8_t> bytes)
+        : Parent(std::move(bytes), LCS_MAX_CONTAINER_DEPTH) {}
 
     size_t deserialize_len();
     uint32_t deserialize_variant_index();

--- a/serde-generate/runtime/cpp/lcs.hpp
+++ b/serde-generate/runtime/cpp/lcs.hpp
@@ -97,7 +97,7 @@ inline uint32_t LcsDeserializer::deserialize_uleb128_as_u32() {
     for (int shift = 0; shift < 32; shift += 7) {
         auto byte = read_byte();
         auto digit = byte & 0x7F;
-        value |= digit << shift;
+        value |= (uint64_t)digit << shift;
         if (value > std::numeric_limits<uint32_t>::max()) {
             throw serde::deserialization_error(
                 "Overflow while parsing uleb128-encoded uint32 value");

--- a/serde-generate/runtime/golang/bincode/deserializer.go
+++ b/serde-generate/runtime/golang/bincode/deserializer.go
@@ -5,6 +5,7 @@ package bincode
 
 import (
 	"errors"
+	"math"
 
 	"github.com/novifinancial/serde-reflection/serde-generate/runtime/golang/serde"
 )
@@ -18,7 +19,7 @@ type deserializer struct {
 }
 
 func NewDeserializer(input []byte) serde.Deserializer {
-	return &deserializer{*serde.NewBinaryDeserializer(input)}
+	return &deserializer{*serde.NewBinaryDeserializer(input, math.MaxUint64)}
 }
 
 func (d *deserializer) DeserializeBytes() ([]byte, error) {

--- a/serde-generate/runtime/golang/bincode/serializer.go
+++ b/serde-generate/runtime/golang/bincode/serializer.go
@@ -4,6 +4,8 @@
 package bincode
 
 import (
+	"math"
+
 	"github.com/novifinancial/serde-reflection/serde-generate/runtime/golang/serde"
 )
 
@@ -13,7 +15,7 @@ type serializer struct {
 }
 
 func NewSerializer() serde.Serializer {
-	return new(serializer)
+	return &serializer{*serde.NewBinarySerializer(math.MaxUint64)}
 }
 
 func (s *serializer) SerializeStr(value string) error {

--- a/serde-generate/runtime/golang/lcs/deserializer.go
+++ b/serde-generate/runtime/golang/lcs/deserializer.go
@@ -10,8 +10,11 @@ import (
 	"github.com/novifinancial/serde-reflection/serde-generate/runtime/golang/serde"
 )
 
-// MaxSequenceLength is max length allowed for sequence.
+// Maximum length allowed for sequences (vectors, bytes, strings) and maps.
 const MaxSequenceLength = (1 << 31) - 1
+
+// Maximum number of nested structs and enum variants.
+const MaxContainerDepth = 500
 
 const maxUint32 = uint64(^uint32(0))
 
@@ -21,7 +24,7 @@ type deserializer struct {
 }
 
 func NewDeserializer(input []byte) serde.Deserializer {
-	return &deserializer{*serde.NewBinaryDeserializer(input)}
+	return &deserializer{*serde.NewBinaryDeserializer(input, MaxContainerDepth)}
 }
 
 func (d *deserializer) DeserializeBytes() ([]byte, error) {

--- a/serde-generate/runtime/golang/lcs/serializer.go
+++ b/serde-generate/runtime/golang/lcs/serializer.go
@@ -17,7 +17,7 @@ type serializer struct {
 }
 
 func NewSerializer() serde.Serializer {
-	return new(serializer)
+	return &serializer{*serde.NewBinarySerializer(MaxContainerDepth)}
 }
 
 func (s *serializer) SerializeStr(value string) error {

--- a/serde-generate/runtime/golang/serde/binary_serializer.go
+++ b/serde-generate/runtime/golang/serde/binary_serializer.go
@@ -11,11 +11,26 @@ import (
 // `BinarySerializer` is a partial implementation of the `Serializer` interface.
 // It is used as an embedded struct by the Bincode and LCS serializers.
 type BinarySerializer struct {
-	Buffer bytes.Buffer
+	Buffer               bytes.Buffer
+	containerDepthBudget uint64
 }
 
-func NewBinarySerializer() *BinarySerializer {
-	return new(BinarySerializer)
+func NewBinarySerializer(max_container_depth uint64) *BinarySerializer {
+	s := new(BinarySerializer)
+	s.containerDepthBudget = max_container_depth
+	return s
+}
+
+func (d *BinarySerializer) IncreaseContainerDepth() error {
+	if d.containerDepthBudget == 0 {
+		return errors.New("exceeded maximum container depth")
+	}
+	d.containerDepthBudget -= 1
+	return nil
+}
+
+func (d *BinarySerializer) DecreaseContainerDepth() {
+	d.containerDepthBudget += 1
 }
 
 // `serializeLen` to be provided by the extending struct.

--- a/serde-generate/runtime/golang/serde/interfaces.go
+++ b/serde-generate/runtime/golang/serde/interfaces.go
@@ -49,6 +49,10 @@ type Serializer interface {
 	SortMapEntries(offsets []uint64)
 
 	GetBytes() []byte
+
+	IncreaseContainerDepth() error
+
+	DecreaseContainerDepth()
 }
 
 type Deserializer interface {
@@ -95,6 +99,10 @@ type Deserializer interface {
 	GetBufferOffset() uint64
 
 	CheckThatKeySlicesAreIncreasing(key1, key2 Slice) error
+
+	IncreaseContainerDepth() error
+
+	DecreaseContainerDepth()
 }
 
 type Slice struct {

--- a/serde-generate/runtime/java/com/novi/bincode/BincodeDeserializer.java
+++ b/serde-generate/runtime/java/com/novi/bincode/BincodeDeserializer.java
@@ -9,7 +9,7 @@ import com.novi.serde.BinaryDeserializer;
 
 public class BincodeDeserializer extends BinaryDeserializer {
     public BincodeDeserializer(byte[] input) {
-        super(input);
+        super(input, Long.MAX_VALUE);
     }
 
     public long deserialize_len() throws DeserializationError {

--- a/serde-generate/runtime/java/com/novi/bincode/BincodeSerializer.java
+++ b/serde-generate/runtime/java/com/novi/bincode/BincodeSerializer.java
@@ -7,6 +7,10 @@ import com.novi.serde.SerializationError;
 import com.novi.serde.BinarySerializer;
 
 public class BincodeSerializer extends BinarySerializer {
+    public BincodeSerializer() {
+        super(Long.MAX_VALUE);
+    }
+
     public void serialize_len(long value) throws SerializationError {
         serialize_u64(value);
     }

--- a/serde-generate/runtime/java/com/novi/lcs/LcsDeserializer.java
+++ b/serde-generate/runtime/java/com/novi/lcs/LcsDeserializer.java
@@ -9,7 +9,7 @@ import com.novi.serde.BinaryDeserializer;
 
 public class LcsDeserializer extends BinaryDeserializer {
     public LcsDeserializer(byte[] input) {
-        super(input);
+        super(input, LcsSerializer.MAX_CONTAINER_DEPTH);
     }
 
     private int deserialize_uleb128_as_u32() throws DeserializationError {
@@ -17,7 +17,7 @@ public class LcsDeserializer extends BinaryDeserializer {
         for (int shift = 0; shift < 32; shift += 7) {
             byte x = getByte();
             byte digit = (byte) (x & 0x7F);
-            value = value | (digit << shift);
+            value = value | ((long)digit << shift);
             if ((value < 0) || (value > Integer.MAX_VALUE)) {
                 throw new DeserializationError("Overflow while parsing uleb128-encoded uint32 value");
             }

--- a/serde-generate/runtime/java/com/novi/lcs/LcsSerializer.java
+++ b/serde-generate/runtime/java/com/novi/lcs/LcsSerializer.java
@@ -9,6 +9,11 @@ import com.novi.serde.BinarySerializer;
 
 public class LcsSerializer extends BinarySerializer {
     public static final long MAX_LENGTH = Integer.MAX_VALUE;
+    public static final long MAX_CONTAINER_DEPTH = 500;
+
+    public LcsSerializer() {
+        super(MAX_CONTAINER_DEPTH);
+    }
 
     private void serialize_u32_as_uleb128(int value) {
         while ((value >>> 7) != 0) {

--- a/serde-generate/runtime/java/com/novi/serde/BinarySerializer.java
+++ b/serde-generate/runtime/java/com/novi/serde/BinarySerializer.java
@@ -7,9 +7,22 @@ import java.math.BigInteger;
 
 public abstract class BinarySerializer implements Serializer {
     protected MyByteArrayOutputStream output;
+    private long containerDepthBudget;
 
-    public BinarySerializer() {
+    public BinarySerializer(long maxContainerDepth) {
         output = new BinarySerializer.MyByteArrayOutputStream();
+        containerDepthBudget = maxContainerDepth;
+    }
+
+    public void increase_container_depth() throws SerializationError {
+        if (containerDepthBudget == 0) {
+            throw new SerializationError("Exceeded maximum container depth");
+        }
+        containerDepthBudget -= 1;
+    }
+
+    public void decrease_container_depth() {
+        containerDepthBudget += 1;
     }
 
     public void serialize_str(String value) throws SerializationError {

--- a/serde-generate/runtime/java/com/novi/serde/Deserializer.java
+++ b/serde-generate/runtime/java/com/novi/serde/Deserializer.java
@@ -46,6 +46,10 @@ public interface Deserializer {
 
     boolean deserialize_option_tag() throws DeserializationError;
 
+    void increase_container_depth() throws DeserializationError;
+
+    void decrease_container_depth();
+
     int get_buffer_offset();
 
     void check_that_key_slices_are_increasing(Slice key1, Slice key2) throws DeserializationError;

--- a/serde-generate/runtime/java/com/novi/serde/Serializer.java
+++ b/serde-generate/runtime/java/com/novi/serde/Serializer.java
@@ -46,6 +46,10 @@ public interface Serializer {
 
     void serialize_option_tag(boolean value) throws SerializationError;
 
+    void increase_container_depth() throws SerializationError;
+
+    void decrease_container_depth();
+
     int get_buffer_offset();
 
     void sort_map_entries(int[] offsets);

--- a/serde-generate/runtime/python/bincode/__init__.py
+++ b/serde-generate/runtime/python/bincode/__init__.py
@@ -4,6 +4,7 @@
 import dataclasses
 import collections
 import typing
+from copy import copy
 from typing import get_type_hints
 
 import serde_types as st
@@ -46,10 +47,10 @@ _bincode_deserialization_config = sb.DeserializationConfig(
 
 
 def serialize(obj: typing.Any, obj_type) -> bytes:
-    return sb.serialize_with_config(_bincode_serialization_config, obj, obj_type, 0)
+    return sb.serialize_with_config(copy(_bincode_serialization_config), obj, obj_type)
 
 
 def deserialize(content: bytes, obj_type) -> typing.Tuple[typing.Any, bytes]:
     return sb.deserialize_with_config(
-        _bincode_deserialization_config, content, obj_type, 0
+        copy(_bincode_deserialization_config), content, obj_type
     )

--- a/serde-generate/runtime/python/lcs/__init__.py
+++ b/serde-generate/runtime/python/lcs/__init__.py
@@ -4,6 +4,7 @@
 import dataclasses
 import collections
 import typing
+from copy import copy
 from typing import get_type_hints
 
 import serde_types as st
@@ -93,8 +94,10 @@ _lcs_deserialization_config = sb.DeserializationConfig(
 
 
 def serialize(obj: typing.Any, obj_type) -> bytes:
-    return sb.serialize_with_config(_lcs_serialization_config, obj, obj_type, 0)
+    return sb.serialize_with_config(copy(_lcs_serialization_config), obj, obj_type)
 
 
 def deserialize(content: bytes, obj_type) -> typing.Tuple[typing.Any, bytes]:
-    return sb.deserialize_with_config(_lcs_deserialization_config, content, obj_type, 0)
+    return sb.deserialize_with_config(
+        copy(_lcs_deserialization_config), content, obj_type
+    )

--- a/serde-generate/runtime/python/lcs/test_lcs.py
+++ b/serde-generate/runtime/python/lcs/test_lcs.py
@@ -220,12 +220,10 @@ class LcsTestCase(unittest.TestCase):
 
         @staticmethod
         def integers(size: int) -> "LcsTestCase.List":
-            if size == 0:
-                return LcsTestCase.List.empty()
-            else:
-                return LcsTestCase.List.cons(
-                    st.uint64(size - 1), LcsTestCase.List.integers(size - 1)
-                )
+            result = LcsTestCase.List.empty()
+            for i in range(size):
+                result = LcsTestCase.List.cons(st.uint64(i), result)
+            return result
 
     def test_max_container_depth(self):
         # Required to avoid RecursionError's in python.

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -542,10 +542,13 @@ return obj, nil
         let fields = match variant {
             Unit => Vec::new(),
             NewType(format) => match format.as_ref() {
-                // We cannot define a "new type" (e.g. `type Foo Bar`) here because the underlying name (`Bar`)
+                // We cannot define a "new type" (e.g. `type Foo Bar`) out of a typename `Bar` because `Bar`
                 // could point to a Go interface. This would make `Foo` an interface as well. Interfaces can't be used
                 // as structs (e.g. they cannot have methods).
-                Format::TypeName(_) => vec![Named {
+                //
+                // Similarly, option types are compiled as pointers but `type Foo *Bar` would prevent `Foo` from being a
+                // valid pointer receiver.
+                Format::TypeName(_) | Format::Option(_) => vec![Named {
                     name: "Value".to_string(),
                     value: format.as_ref().clone(),
                 }],
@@ -878,7 +881,7 @@ switch index {{"#,
             UnitStruct => Vec::new(),
             NewTypeStruct(format) => match format.as_ref() {
                 // See comment in `output_variant`.
-                Format::TypeName(_) => vec![Named {
+                Format::TypeName(_) | Format::Option(_) => vec![Named {
                     name: "Value".to_string(),
                     value: format.as_ref().clone(),
                 }],

--- a/serde-generate/src/golang.rs
+++ b/serde-generate/src/golang.rs
@@ -619,6 +619,10 @@ return obj, nil
                 full_name
             )?;
             self.out.indent();
+            writeln!(
+                self.out,
+                "if err := serializer.IncreaseContainerDepth(); err != nil {{ return err }}"
+            )?;
             if let Some(index) = variant_index {
                 writeln!(self.out, "serializer.SerializeVariantIndex({})", index)?;
             }
@@ -629,6 +633,7 @@ return obj, nil
                     self.quote_serialize_value(&format!("obj.{}", &field.name), &field.value)
                 )?;
             }
+            writeln!(self.out, "serializer.DecreaseContainerDepth()")?;
             writeln!(self.out, "return nil")?;
             self.out.unindent();
             writeln!(self.out, "}}")?;
@@ -651,6 +656,10 @@ return obj, nil
             )?;
             self.out.indent();
             writeln!(self.out, "var obj {}", full_name)?;
+            writeln!(
+                self.out,
+                "if err := deserializer.IncreaseContainerDepth(); err != nil {{ return obj, err }}"
+            )?;
             for field in fields {
                 writeln!(
                     self.out,
@@ -658,6 +667,7 @@ return obj, nil
                     self.quote_deserialize(&field.value, &format!("obj.{}", field.name), "obj")
                 )?;
             }
+            writeln!(self.out, "deserializer.DecreaseContainerDepth()")?;
             writeln!(self.out, "return obj, nil")?;
             self.out.unindent();
             writeln!(self.out, "}}")?;
@@ -702,6 +712,10 @@ return obj, nil
                 full_name
             )?;
             self.out.indent();
+            writeln!(
+                self.out,
+                "if err := serializer.IncreaseContainerDepth(); err != nil {{ return err }}"
+            )?;
             if let Some(index) = variant_index {
                 writeln!(self.out, "serializer.SerializeVariantIndex({})", index)?;
             }
@@ -713,6 +727,7 @@ return obj, nil
                     format
                 )
             )?;
+            writeln!(self.out, "serializer.DecreaseContainerDepth()")?;
             writeln!(self.out, "return nil")?;
             self.out.unindent();
             writeln!(self.out, "}}")?;
@@ -735,11 +750,13 @@ return obj, nil
             )?;
             self.out.indent();
             writeln!(self.out, "var obj {}", self.quote_type(format))?;
+            writeln!(self.out, "if err := deserializer.IncreaseContainerDepth(); err != nil {{ return ({})(obj), err }}", full_name)?;
             writeln!(
                 self.out,
                 "{}",
                 self.quote_deserialize(format, "obj", &format!("(({})(obj))", full_name))
             )?;
+            writeln!(self.out, "deserializer.DecreaseContainerDepth()")?;
             writeln!(self.out, "return ({})(obj), nil", full_name)?;
             self.out.unindent();
             writeln!(self.out, "}}")?;

--- a/serde-generate/src/java.rs
+++ b/serde-generate/src/java.rs
@@ -644,6 +644,7 @@ return obj;
                 "\npublic void serialize(com.novi.serde.Serializer serializer) throws com.novi.serde.SerializationError {{",
             )?;
             self.out.indent();
+            writeln!(self.out, "serializer.increase_container_depth();")?;
             if let Some(index) = variant_index {
                 writeln!(self.out, "serializer.serialize_variant_index({});", index)?;
             }
@@ -654,6 +655,7 @@ return obj;
                     self.quote_serialize_value(&field.name, &field.value)
                 )?;
             }
+            writeln!(self.out, "serializer.decrease_container_depth();")?;
             self.out.unindent();
             writeln!(self.out, "}}")?;
 
@@ -679,6 +681,7 @@ return obj;
                 )?;
             }
             self.out.indent();
+            writeln!(self.out, "deserializer.increase_container_depth();")?;
             writeln!(self.out, "Builder builder = new Builder();")?;
             for field in fields {
                 writeln!(
@@ -688,6 +691,7 @@ return obj;
                     self.quote_deserialize(&field.value)
                 )?;
             }
+            writeln!(self.out, "deserializer.decrease_container_depth();")?;
             writeln!(self.out, "return builder.build();")?;
             self.out.unindent();
             writeln!(self.out, "}}")?;

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -65,10 +65,10 @@
 //! writeln!(
 //!     source,
 //!     r#"
-//! value = Test.bincode_deserialize(bytes.fromhex("{}"))
+//! value = Test.bincode_deserialize(bytes({:?}))
 //! assert value == Test(a=[4, 6], b=(3, 5))
 //! "#,
-//!     hex::encode(&bincode::serialize(&Test { a: vec![4, 6], b: (3, 5) }).unwrap()),
+//!     bincode::serialize(&Test { a: vec![4, 6], b: (3, 5) }).unwrap(),
 //! )?;
 //!
 //! // Execute the Python code.

--- a/serde-generate/src/test_utils.rs
+++ b/serde-generate/src/test_utils.rs
@@ -508,7 +508,7 @@ impl Runtime {
         if depth < 2 {
             return None;
         }
-        let e = self.serialize::<List<SerdeData>>(&List::Empty);
+        let mut e = self.serialize::<List<SerdeData>>(&List::Empty);
 
         let f0 = self.serialize(&List::Node(
             Box::new(SerdeData::UnitVariant),
@@ -522,7 +522,7 @@ impl Runtime {
         for _ in 2..depth {
             result.append(&mut f.clone());
         }
-        result.append(&mut e.clone());
+        result.append(&mut e);
         Some(result)
     }
 
@@ -533,7 +533,7 @@ impl Runtime {
         if depth < 2 {
             return None;
         }
-        let e = self.serialize::<SimpleList>(&SimpleList(None));
+        let mut e = self.serialize::<SimpleList>(&SimpleList(None));
 
         let f0 = self.serialize(&SimpleList(Some(Box::new(SimpleList(None)))));
         let f = f0[..f0.len() - e.len()].to_vec();
@@ -544,7 +544,7 @@ impl Runtime {
         for _ in 2..depth {
             result.append(&mut f.clone());
         }
-        result.append(&mut e.clone());
+        result.append(&mut e);
         Some(result)
     }
 

--- a/serde-generate/src/test_utils.rs
+++ b/serde-generate/src/test_utils.rs
@@ -290,7 +290,7 @@ impl Runtime {
     pub fn rust_package(self) -> &'static str {
         match self {
             Self::Lcs => "lcs = { git = \"https://github.com/libra/libra.git\", branch = \"testnet\", package = \"libra-canonical-serialization\" }",
-            Self::Bincode => "bincode = \"1.2\"",
+            Self::Bincode => "bincode = \"1.3\"",
         }
     }
 

--- a/serde-generate/src/test_utils.rs
+++ b/serde-generate/src/test_utils.rs
@@ -332,7 +332,7 @@ impl Runtime {
 
     pub fn rust_package(self) -> &'static str {
         match self {
-            Self::Lcs => "lcs = { git = \"https://github.com/libra/libra.git\", branch = \"testnet\", package = \"libra-canonical-serialization\" }",
+            Self::Lcs => "lcs = { git = \"https://github.com/libra/libra.git\", branch = \"auto\", package = \"libra-canonical-serialization\" }",
             Self::Bincode => "bincode = \"1.3\"",
         }
     }

--- a/serde-generate/tests/analyzer.rs
+++ b/serde-generate/tests/analyzer.rs
@@ -71,7 +71,8 @@ fn test_on_larger_registry() {
             "Struct",
             "Tree",
             "TupleStruct",
-            "UnitStruct"
+            "UnitStruct",
+            "SimpleList",
         )
     );
 
@@ -84,6 +85,7 @@ fn test_on_larger_registry() {
             "Struct",
             "OtherTypes",
             "PrimitiveTypes",
+            "SimpleList",
             "Tree",
             "TupleStruct",
             "UnitStruct",

--- a/serde-generate/tests/cpp_generation.rs
+++ b/serde-generate/tests/cpp_generation.rs
@@ -42,7 +42,7 @@ fn test_that_cpp_code_compiles_with_config(
         .unwrap();
     assert!(status.success());
 
-    (dir, header_path.clone())
+    (dir, header_path)
 }
 
 #[test]

--- a/serde-generate/tests/golang_generation.rs
+++ b/serde-generate/tests/golang_generation.rs
@@ -81,12 +81,12 @@ fn test_that_golang_code_compiles_with_config_and_registry(
     let status = Command::new("go")
         .current_dir(dir.path())
         .arg("build")
-        .arg(source_path.clone())
+        .arg(&source_path)
         .status()
         .unwrap();
     assert!(status.success());
 
-    (dir, source_path.clone())
+    (dir, source_path)
 }
 
 #[test]

--- a/serde-generate/tests/golang_runtime.rs
+++ b/serde-generate/tests/golang_runtime.rs
@@ -125,7 +125,7 @@ func main() {{
     let status = Command::new("go")
         .current_dir(dir.path())
         .arg("run")
-        .arg(source_path.clone())
+        .arg(&source_path)
         .status()
         .unwrap();
     assert!(status.success());

--- a/serde-generate/tests/golang_runtime.rs
+++ b/serde-generate/tests/golang_runtime.rs
@@ -157,11 +157,10 @@ fn test_golang_runtime_on_supported_types(runtime: Runtime) {
     let generator = golang::CodeGenerator::new(&config);
     generator.output(&mut source, &registry).unwrap();
 
-    let values = test_utils::get_sample_values(runtime.has_canonical_maps());
-    let encodings = values
+    let encodings = runtime
+        .get_positive_samples()
         .iter()
-        .map(|v| {
-            let bytes = runtime.serialize(&v);
+        .map(|bytes| {
             format!(
                 "{{{}}}",
                 bytes

--- a/serde-generate/tests/java_runtime.rs
+++ b/serde-generate/tests/java_runtime.rs
@@ -132,6 +132,17 @@ fn test_java_bincode_runtime_on_supported_types() {
     test_java_runtime_on_supported_types(Runtime::Bincode);
 }
 
+fn quote_bytes(bytes: &[u8]) -> String {
+    format!(
+        "{{{}}}",
+        bytes
+            .iter()
+            .map(|x| format!("{}", *x as i8))
+            .collect::<Vec<_>>()
+            .join(", ")
+    )
+}
+
 fn test_java_runtime_on_supported_types(runtime: Runtime) {
     let registry = test_utils::get_registry().unwrap();
     let dir = tempdir().unwrap();
@@ -143,21 +154,17 @@ fn test_java_runtime_on_supported_types(runtime: Runtime) {
         .write_source_files(dir.path().to_path_buf(), &registry)
         .unwrap();
 
-    let encodings = runtime
+    let positive_encodings: Vec<_> = runtime
         .get_positive_samples_quick()
         .iter()
-        .map(|bytes| {
-            format!(
-                "\n{{{}}}",
-                bytes
-                    .iter()
-                    .map(|x| format!("{}", *x as i8))
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            )
-        })
-        .collect::<Vec<_>>()
-        .join(", ");
+        .map(|bytes| quote_bytes(bytes))
+        .collect();
+
+    let negative_encodings: Vec<_> = runtime
+        .get_negative_samples()
+        .iter()
+        .map(|bytes| quote_bytes(bytes))
+        .collect();
 
     let mut source = File::create(&dir.path().join("Main.java")).unwrap();
     writeln!(
@@ -171,12 +178,13 @@ import com.novi.serde.Tuple2;
 import testing.SerdeData;
 
 public class Main {{
-    public static void main(String[] args) throws java.lang.Exception {{
-        byte[][] inputs = new byte[][] {{{0}}};
+    static final byte[][] positive_inputs = new byte[][] {{{0}}};
+    static final byte[][] negative_inputs = new byte[][] {{{1}}};
 
-        for (byte[] input : inputs) {{
-            SerdeData test = SerdeData.{1}Deserialize(input);
-            byte[] output = test.{1}Serialize();
+    public static void main(String[] args) throws java.lang.Exception {{
+        for (byte[] input : positive_inputs) {{
+            SerdeData test = SerdeData.{2}Deserialize(input);
+            byte[] output = test.{2}Serialize();
 
             assert java.util.Arrays.equals(input, output);
 
@@ -185,7 +193,7 @@ public class Main {{
                 byte[] input2 = input.clone();
                 input2[i] ^= 0x80;
                 try {{
-                    SerdeData test2 = SerdeData.{1}Deserialize(input2);
+                    SerdeData test2 = SerdeData.{2}Deserialize(input2);
                     assert test2 != test;
                 }} catch (DeserializationError e) {{
                     // All good
@@ -193,10 +201,22 @@ public class Main {{
             }}
 
         }}
+
+        for (byte[] input : negative_inputs) {{
+            try {{
+                SerdeData test = SerdeData.{2}Deserialize(input);
+                Integer[] bytes = new Integer[input.length];
+                Arrays.setAll(bytes, n -> Math.floorMod(input[n], 256));
+                throw new Exception("Input should fail to deserialize: " + Arrays.asList(bytes));
+            }} catch (DeserializationError e) {{
+                    // All good
+            }}
+        }}
     }}
 }}
 "#,
-        encodings,
+        positive_encodings.join(", "),
+        negative_encodings.join(", "),
         runtime.name(),
     )
     .unwrap();

--- a/serde-generate/tests/java_runtime.rs
+++ b/serde-generate/tests/java_runtime.rs
@@ -143,11 +143,10 @@ fn test_java_runtime_on_supported_types(runtime: Runtime) {
         .write_source_files(dir.path().to_path_buf(), &registry)
         .unwrap();
 
-    let values = test_utils::get_sample_values(runtime.has_canonical_maps());
-    let encodings = values
+    let encodings = runtime
+        .get_positive_samples_quick()
         .iter()
-        .map(|v| {
-            let bytes = runtime.serialize(&v);
+        .map(|bytes| {
             format!(
                 "\n{{{}}}",
                 bytes

--- a/serde-generate/tests/python_generation.rs
+++ b/serde-generate/tests/python_generation.rs
@@ -25,13 +25,13 @@ fn test_that_python_code_parses_with_config(
         std::env::var("PYTHONPATH").unwrap_or_default()
     );
     let status = Command::new("python3")
-        .arg(source_path.clone())
+        .arg(&source_path)
         .env("PYTHONPATH", python_path)
         .status()
         .unwrap();
     assert!(status.success());
 
-    (dir, source_path.clone())
+    (dir, source_path)
 }
 
 #[test]

--- a/serde-generate/tests/rust_generation.rs
+++ b/serde-generate/tests/rust_generation.rs
@@ -25,12 +25,12 @@ fn test_that_rust_code_compiles_with_config(
         .arg("lib")
         .arg("--edition")
         .arg("2018")
-        .arg(source_path.clone())
+        .arg(&source_path)
         .status()
         .unwrap();
     assert!(status.success());
 
-    (dir, source_path.clone())
+    (dir, source_path)
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn test_that_rust_code_compiles_with_external_definitions() {
         .arg("lib")
         .arg("--edition")
         .arg("2018")
-        .arg(source_path.clone())
+        .arg(&source_path)
         .output()
         .unwrap();
     assert!(!output.status.success()); // Must fail.
@@ -106,7 +106,7 @@ mod foo {{
         .arg("lib")
         .arg("--edition")
         .arg("2018")
-        .arg(source_path)
+        .arg(&source_path)
         .status()
         .unwrap();
     assert!(status.success());

--- a/serde-generate/tests/rust_runtime.rs
+++ b/serde-generate/tests/rust_runtime.rs
@@ -32,7 +32,7 @@ edition = "2018"
 
 [dependencies]
 hex = "0.4.2"
-serde = {{ version = "1.0.112", features = ["derive"] }}
+serde = {{ version = "1.0", features = ["derive"] }}
 serde_bytes = "0.11"
 {}
 

--- a/serde-reflection/Cargo.toml
+++ b/serde-reflection/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
-bincode = "1.2"
+bincode = "1.3.1"
 serde_json = "1.0"
 serde_yaml = "0.8"
 serde_bytes = "0.11.3"


### PR DESCRIPTION
## Summary

* Use Rust as a baseline to test that supported languages reject incorrect byte strings during LCS deserialization
* Introduce a generated list of "negative" samples for this purpose. Samples are typically obtained by flipping the highest bit of a byte in a valid sample, and testing if Rust can deserialize.
* In all languages, we now also mutate "positive samples" and check that they always decode to a different value (by canonicity)
* The new testing approach covers exceeding input bytes, UTF8 validation, boolean decoding, map key ordering, the length limit of sequences, and the limit on container depth.
* Also, fix a codegen issue in golang for containers of the form `struct Foo(Option<T>)`

## Test Plan

CI