### PR TITLE
[serde generate] python: switch to "frozen" dataclasses

### DIFF
--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -54,7 +54,7 @@
 //! assert!(
 //!     String::from_utf8_lossy(&source).contains(
 //!     r#"
-//! @dataclass
+//! @dataclass(frozen=True)
 //! class Test:
 //!     a: typing.Sequence[st.uint64]
 //!     b: typing.Tuple[st.uint32, st.uint32]

--- a/serde-generate/src/python3.rs
+++ b/serde-generate/src/python3.rs
@@ -227,7 +227,11 @@ import typing
         };
 
         // Regarding comments, we pretend the namespace is `[module, base, name]`.
-        writeln!(self.out, "\n@dataclass\nclass {0}__{1}({0}):", base, name)?;
+        writeln!(
+            self.out,
+            "\n@dataclass(frozen=True)\nclass {0}__{1}({0}):",
+            base, name
+        )?;
         self.out.indent();
         self.output_comment(&name)?;
         if self.generator.config.serialization {
@@ -339,7 +343,7 @@ def {0}_deserialize(input: bytes) -> '{1}':
             }
         };
         // Struct case.
-        writeln!(self.out, "\n@dataclass\nclass {}:", name)?;
+        writeln!(self.out, "\n@dataclass(frozen=True)\nclass {}:", name)?;
         self.out.indent();
         self.output_comment(name)?;
         self.current_namespace.push(name.to_string());

--- a/serde-generate/tests/python_runtime.rs
+++ b/serde-generate/tests/python_runtime.rs
@@ -51,7 +51,7 @@ v = Test.{0}_deserialize(s)
 assert v == value
 assert v.c.x == 7
 
-v.b = (3, 0)
+v = Test([4, 6], (3, 0), Choice__C(7))
 t = v.{0}_serialize()
 assert len(t) == len(s)
 assert t != s


### PR DESCRIPTION
## Summary

Generate dataclass definitions with `frozen=True`
* This will make hashing available for more complex datatypes (hence dictionaries -- aka. Serde maps)
* This could also come handy in the future (e.g. to enforce value invariants in a post_init method).

## Test Plan

CI