### PR TITLE
[serde generate] add floats to Python bincode runtime

### DIFF
--- a/serde-generate/runtime/python/bincode/test_bincode.py
+++ b/serde-generate/runtime/python/bincode/test_bincode.py
@@ -81,6 +81,23 @@ class BincodeTestCase(unittest.TestCase):
             bincode.deserialize(b"\xff" * 16, st.int128), (st.int128(-1), b"")
         )
 
+    def test_bincode_f32(self):
+        self.assertEqual(bincode.serialize(0.3, st.float32), b"\x9a\x99\x99\x3e")
+        value, reminder = bincode.deserialize(b"\x9a\x99\x99\x3e", st.float32)
+        self.assertEqual(reminder, b"")
+        self.assertAlmostEqual(value, 0.3)
+
+    def test_bincode_f64(self):
+        self.assertEqual(
+            bincode.serialize(0.000000000003, st.float64),
+            b"\x1a\xdf\xc4\x41\x66\x63\x8a\x3d",
+        )
+        value, reminder = bincode.deserialize(
+            b"\x1a\xdf\xc4\x41\x66\x63\x8a\x3d", st.float64
+        )
+        self.assertEqual(reminder, b"")
+        self.assertAlmostEqual(value, 0.000000000003)
+
     def test_serialize_bytes(self):
         self.assertEqual(bincode.serialize(b"", bytes), b"\x00" * 8)
         self.assertEqual(


### PR DESCRIPTION
## Summary

Let's follow the Rust implementation of `bincode` and add support for floats (in the IEEE 754 format, little endian).
In this PR, we start with python.

## Test Plan

unit test