### PR TITLE
[serde generate] switch to LCS crate + remove feature "runtime-testing"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
-
-[[package]]
 name = "bincode"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,37 +43,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
-name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "byteorder"
 version = "1.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
-
-[[package]]
-name = "bytes"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.61"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed67cbde08356238e75fc4656be4749481eeffb09e19f320a25237d5221c985d"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -103,41 +70,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
-
-[[package]]
-name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "dtoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134951f4028bdadb9b84baf4232681efbf277da25144b9b0ad65df75946c422b"
-
-[[package]]
-name = "fixedbitset"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ab347416e802de484e4d03c7316c48f1ecb56574dfd4a46a80f173ce1de04d"
-
-[[package]]
-name = "generic-array"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
-dependencies = [
- "typenum",
- "version_check",
-]
 
 [[package]]
 name = "getrandom"
@@ -155,12 +91,6 @@ name = "glob"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
-
-[[package]]
-name = "hashbrown"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
 name = "heck"
@@ -211,29 +141,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "indexmap"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55e2e4c765aa53a0424761bf9f41aa7a6ac1efa87238f59560640e27fca028f2"
-dependencies = [
- "autocfg",
- "hashbrown",
-]
-
-[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
-
-[[package]]
-name = "jobserver"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c71313ebb9439f74b00d9d2dcec36440beaf57a6aa0623068441dd7cd81a7f2"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "lazy_static"
@@ -250,28 +161,11 @@ checksum = "2448f6066e80e3bfc792e9c98bf705b4b0fc6e8ef5b43e5889aff0eaa9c58743"
 [[package]]
 name = "libra-canonical-serialization"
 version = "0.1.0"
-source = "git+https://github.com/libra/libra.git?branch=auto#10dc3cb9e645eec840139508b9d813ea6dc7108e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8dddda30939e963210412740c920779b3b57d0b8ab58d94d562cc433d621f1"
 dependencies = [
- "libra-workspace-hack",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "libra-workspace-hack"
-version = "0.1.0"
-source = "git+https://github.com/libra/libra.git?branch=auto#10dc3cb9e645eec840139508b9d813ea6dc7108e"
-dependencies = [
- "bytes",
- "cc",
- "log",
- "memchr",
- "num-traits",
- "petgraph",
- "serde",
- "sha-1",
- "subtle",
- "syn",
 ]
 
 [[package]]
@@ -281,51 +175,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
 
 [[package]]
-name = "log"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fabed175da42fed1fa0746b0ea71f412aa9d35e76e95e59b192c64b9dc2bf8b"
-dependencies = [
- "cfg-if",
- "serde",
-]
-
-[[package]]
 name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
-
-[[package]]
-name = "memchr"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
-
-[[package]]
-name = "num-traits"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
-
-[[package]]
-name = "petgraph"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "467d164a6de56270bd7c4d070df81d07beace25012d5103ced4e9ff08d6afdb7"
-dependencies = [
- "fixedbitset",
- "indexmap",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -537,19 +390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "170a36ea86c864a3f16dd2687712dd6646f7019f301e57537c7f4dc9f5916770"
-dependencies = [
- "block-buffer",
- "cfg-if",
- "cpuid-bool",
- "digest",
- "opaque-debug",
-]
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -578,12 +418,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "subtle"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "343f3f510c2915908f155e94f17220b19ccfacf2a64a2a5d8004f2c3e311e7fd"
 
 [[package]]
 name = "syn"
@@ -630,29 +464,23 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
+checksum = "0e9ae34b84616eedaaf1e9dd6026dbe00dcafa92aa0c8077cb69df1fcfe5e53e"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+checksum = "9ba20f23e85b10754cd195504aebf6a27e2e6cbe28c17778a0c930724628dd56"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "typenum"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unicode-segmentation"

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -15,9 +15,6 @@ exclude = [
     "README.tpl",
 ]
 
-[features]
-runtime-testing = ["libra-canonical-serialization", "bincode"]
-
 [dependencies]
 heck = "0.3.1"
 include_dir = "0.6"
@@ -29,12 +26,10 @@ structopt = "0.3.12"
 textwrap = "0.12.1"
 
 serde-reflection = { path = "../serde-reflection", version = "0.3.0" }
-
-bincode = { version = "1.3.1", optional = true }
-libra-canonical-serialization = { git = "https://github.com/libra/libra.git", branch = "auto", optional = true }
+bincode = { version = "1.3.1" }
+libra-canonical-serialization = { version = "0.1.0" }
 
 [dev-dependencies]
-bincode = { version = "1.3.1" }
 tempfile = "3.1"
 hex = "0.4.2"
 which = "4.0.2"

--- a/serde-generate/src/test_utils.rs
+++ b/serde-generate/src/test_utils.rs
@@ -276,7 +276,6 @@ pub fn get_sample_values(has_canonical_maps: bool, has_floats: bool) -> Vec<Serd
 }
 
 #[cfg(test)]
-#[cfg(feature = "runtime-testing")]
 // Used to test limits on "container depth".
 fn get_sample_value_with_container_depth(depth: usize) -> Option<SerdeData> {
     if depth < 2 {
@@ -290,7 +289,6 @@ fn get_sample_value_with_container_depth(depth: usize) -> Option<SerdeData> {
 }
 
 #[cfg(test)]
-#[cfg(feature = "runtime-testing")]
 // Used to test limits on "container depth".
 fn get_alternate_sample_value_with_container_depth(depth: usize) -> Option<SerdeData> {
     if depth < 2 {
@@ -304,7 +302,6 @@ fn get_alternate_sample_value_with_container_depth(depth: usize) -> Option<Serde
 }
 
 #[cfg(test)]
-#[cfg(feature = "runtime-testing")]
 // Used to test limits on sequence lengths and container depth.
 fn get_sample_value_with_long_sequence(length: usize) -> SerdeData {
     SerdeData::UnitVector(vec![(); length])
@@ -333,12 +330,13 @@ impl Runtime {
 
     pub fn rust_package(self) -> &'static str {
         match self {
-            Self::Lcs => "lcs = { git = \"https://github.com/libra/libra.git\", branch = \"auto\", package = \"libra-canonical-serialization\" }",
+            Self::Lcs => {
+                "lcs = { version = \"0.1.0\", package = \"libra-canonical-serialization\" }"
+            }
             Self::Bincode => "bincode = \"1.3\"",
         }
     }
 
-    #[cfg(feature = "runtime-testing")]
     pub fn serialize<T>(self, value: &T) -> Vec<u8>
     where
         T: serde::Serialize,
@@ -349,7 +347,6 @@ impl Runtime {
         }
     }
 
-    #[cfg(feature = "runtime-testing")]
     pub fn deserialize<T>(self, bytes: &[u8]) -> Option<T>
     where
         T: serde::de::DeserializeOwned,
@@ -362,7 +359,6 @@ impl Runtime {
 
     /// Serialize a value then add noise to the serialized bits repeatedly. Additionally return
     /// `true` if the deserialization of each modified bitstring should succeed.
-    #[cfg(feature = "runtime-testing")]
     pub fn serialize_with_noise_and_deserialize<T>(self, value: &T) -> Vec<(Vec<u8>, bool)>
     where
         T: serde::Serialize + serde::de::DeserializeOwned,
@@ -437,7 +433,6 @@ impl Runtime {
         }
     }
 
-    #[cfg(feature = "runtime-testing")]
     pub fn maximum_length(self) -> Option<usize> {
         match self {
             Self::Lcs => Some(libra_canonical_serialization::MAX_SEQUENCE_LENGTH),
@@ -445,7 +440,6 @@ impl Runtime {
         }
     }
 
-    #[cfg(feature = "runtime-testing")]
     pub fn maximum_container_depth(self) -> Option<usize> {
         match self {
             Self::Lcs => Some(libra_canonical_serialization::MAX_CONTAINER_DEPTH),
@@ -453,7 +447,6 @@ impl Runtime {
         }
     }
 
-    #[cfg(feature = "runtime-testing")]
     pub fn get_positive_samples_quick(self) -> Vec<Vec<u8>> {
         let values = get_sample_values(self.has_canonical_maps(), self.has_floats());
         let mut positive_samples = Vec::new();
@@ -477,7 +470,6 @@ impl Runtime {
         positive_samples
     }
 
-    #[cfg(feature = "runtime-testing")]
     pub fn get_positive_samples(self) -> Vec<Vec<u8>> {
         let mut positive_samples = self.get_positive_samples_quick();
         if let Some(length) = self.maximum_length() {
@@ -486,7 +478,6 @@ impl Runtime {
         positive_samples
     }
 
-    #[cfg(feature = "runtime-testing")]
     pub fn get_negative_samples(self) -> Vec<Vec<u8>> {
         let values = get_sample_values(self.has_canonical_maps(), self.has_floats());
         let mut negative_samples = Vec::new();
@@ -518,7 +509,6 @@ impl Runtime {
 
     // Used to test limits on "container depth".
     // Here we construct the serialized bytes directly to allow examples outside the limit.
-    #[cfg(feature = "runtime-testing")]
     pub fn get_sample_with_container_depth(self, depth: usize) -> Option<Vec<u8>> {
         if depth < 2 {
             return None;
@@ -543,7 +533,6 @@ impl Runtime {
 
     // Used to test limits on "container depth".
     // Here we construct the serialized bytes directly to allow examples outside the limit.
-    #[cfg(feature = "runtime-testing")]
     pub fn get_alternate_sample_with_container_depth(self, depth: usize) -> Option<Vec<u8>> {
         if depth < 2 {
             return None;
@@ -565,7 +554,6 @@ impl Runtime {
 
     // Used to test limits on sequence lengths and container depth.
     // Here we construct the serialized bytes directly to allow examples outside the limit.
-    #[cfg(feature = "runtime-testing")]
     pub fn get_sample_with_long_sequence(self, length: usize) -> Vec<u8> {
         let e = self.serialize::<Vec<()>>(&Vec::new());
         let f0 = self.serialize(&SerdeData::UnitVector(Vec::new()));
@@ -761,13 +749,11 @@ UnitStruct: UNITSTRUCT
 }
 
 #[test]
-#[cfg(feature = "runtime-testing")]
 fn test_bincode_get_sample_with_long_sequence() {
     test_get_sample_with_long_sequence(Runtime::Bincode);
 }
 
 #[test]
-#[cfg(feature = "runtime-testing")]
 fn test_lcs_get_sample_with_long_sequence() {
     test_get_sample_with_long_sequence(Runtime::Lcs);
 }
@@ -775,7 +761,6 @@ fn test_lcs_get_sample_with_long_sequence() {
 // Make sure the direct computation of the serialization of these test values
 // agrees with the usual serialization.
 #[cfg(test)]
-#[cfg(feature = "runtime-testing")]
 fn test_get_sample_with_long_sequence(runtime: Runtime) {
     let value = get_sample_value_with_long_sequence(0);
     assert_eq!(
@@ -797,14 +782,12 @@ fn test_get_sample_with_long_sequence(runtime: Runtime) {
 }
 
 #[test]
-#[cfg(feature = "runtime-testing")]
 fn test_bincode_samples_with_container_depth() {
     test_get_sample_with_container_depth(Runtime::Bincode);
     test_get_alternate_sample_with_container_depth(Runtime::Bincode);
 }
 
 #[test]
-#[cfg(feature = "runtime-testing")]
 fn test_lcs_samples_with_container_depth() {
     test_get_sample_with_container_depth(Runtime::Lcs);
     test_get_alternate_sample_with_container_depth(Runtime::Lcs);
@@ -813,7 +796,6 @@ fn test_lcs_samples_with_container_depth() {
 // Make sure the direct computation of the serialization of these test values
 // agrees with the usual serialization.
 #[cfg(test)]
-#[cfg(feature = "runtime-testing")]
 fn test_get_sample_with_container_depth(runtime: Runtime) {
     let value = get_sample_value_with_container_depth(2).unwrap();
     assert_eq!(
@@ -837,7 +819,6 @@ fn test_get_sample_with_container_depth(runtime: Runtime) {
 // Make sure the direct computation of the serialization of these test values
 // agrees with the usual serialization.
 #[cfg(test)]
-#[cfg(feature = "runtime-testing")]
 fn test_get_alternate_sample_with_container_depth(runtime: Runtime) {
     let value = get_alternate_sample_value_with_container_depth(2).unwrap();
     assert_eq!(
@@ -865,7 +846,6 @@ fn test_get_alternate_sample_with_container_depth(runtime: Runtime) {
 }
 
 #[test]
-#[cfg(feature = "runtime-testing")]
 fn test_bincode_get_positive_samples() {
     assert_eq!(test_get_positive_samples(Runtime::Bincode), 14);
 }
@@ -873,7 +853,6 @@ fn test_bincode_get_positive_samples() {
 #[test]
 // This test requires --release because of deserialization of long (unit) vectors.
 #[cfg(not(debug_assertions))]
-#[cfg(feature = "runtime-testing")]
 fn test_lcs_get_positive_samples() {
     assert_eq!(test_get_positive_samples(Runtime::Lcs), 87);
 }
@@ -881,7 +860,6 @@ fn test_lcs_get_positive_samples() {
 // Make sure all the "positive" samples successfully deserialize with the reference Rust
 // implementation.
 #[cfg(test)]
-#[cfg(feature = "runtime-testing")]
 fn test_get_positive_samples(runtime: Runtime) -> usize {
     let samples = runtime.get_positive_samples();
     let length = samples.len();
@@ -892,7 +870,6 @@ fn test_get_positive_samples(runtime: Runtime) -> usize {
 }
 
 #[test]
-#[cfg(feature = "runtime-testing")]
 fn test_bincode_get_negative_samples() {
     assert_eq!(test_get_negative_samples(Runtime::Bincode), 0);
 }
@@ -900,7 +877,6 @@ fn test_bincode_get_negative_samples() {
 #[test]
 // This test requires --release because of deserialization of long (unit) vectors.
 #[cfg(not(debug_assertions))]
-#[cfg(feature = "runtime-testing")]
 fn test_lcs_get_negative_samples() {
     assert_eq!(test_get_negative_samples(Runtime::Lcs), 57);
 }
@@ -908,7 +884,6 @@ fn test_lcs_get_negative_samples() {
 // Make sure all the "negative" samples fail to deserialize with the reference Rust
 // implementation.
 #[cfg(test)]
-#[cfg(feature = "runtime-testing")]
 fn test_get_negative_samples(runtime: Runtime) -> usize {
     let samples = runtime.get_negative_samples();
     let length = samples.len();
@@ -919,7 +894,6 @@ fn test_get_negative_samples(runtime: Runtime) -> usize {
 }
 
 #[test]
-#[cfg(feature = "runtime-testing")]
 fn test_lcs_serialize_with_noise_and_deserialize() {
     let value = "\u{10348}.".to_string();
     let samples = Runtime::Lcs.serialize_with_noise_and_deserialize(&value);

--- a/serde-generate/tests/cpp_runtime.rs
+++ b/serde-generate/tests/cpp_runtime.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
-#![cfg(feature = "runtime-testing")]
 
 use serde_generate::{
     cpp, test_utils,

--- a/serde-generate/tests/golang_runtime.rs
+++ b/serde-generate/tests/golang_runtime.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
-#![cfg(feature = "runtime-testing")]
 
 use heck::CamelCase;
 use serde_generate::{

--- a/serde-generate/tests/java_runtime.rs
+++ b/serde-generate/tests/java_runtime.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
-#![cfg(feature = "runtime-testing")]
 
 use serde_generate::{
     java, test_utils,

--- a/serde-generate/tests/python_runtime.rs
+++ b/serde-generate/tests/python_runtime.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
-#![cfg(feature = "runtime-testing")]
 
 use serde_generate::{
     python3, test_utils,

--- a/serde-generate/tests/rust_runtime.rs
+++ b/serde-generate/tests/rust_runtime.rs
@@ -1,6 +1,5 @@
 // Copyright (c) Facebook, Inc. and its affiliates
 // SPDX-License-Identifier: MIT OR Apache-2.0
-#![cfg(feature = "runtime-testing")]
 
 use serde_generate::{rust, test_utils, test_utils::Runtime, CodeGeneratorConfig};
 use std::fs::File;

--- a/serde-name/Cargo.toml
+++ b/serde-name/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-thiserror = "1.0"
+thiserror = "1.0.22"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]

--- a/serde-reflection/Cargo.toml
+++ b/serde-reflection/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-thiserror = "1.0"
+thiserror = "1.0.22"
 serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]


### PR DESCRIPTION
## Summary

Libra-Canonical-Serialization (LCS) is now available as a crate so we don't need to (conditionally) pull `libra.git` for testing.

## Test Plan

CI