### PR TITLE
[serde-generate] More improvements in C# codegen

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.16.1"
+version = "0.17.0"
 dependencies = [
  "bincode",
  "heck",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.16.1"
+version = "0.17.0"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/novifinancial/serde-reflection"

--- a/serde-generate/src/csharp.rs
+++ b/serde-generate/src/csharp.rs
@@ -25,7 +25,7 @@ pub struct CodeGenerator<'a> {
 }
 
 /// Shared state for the code generation of a C# source file.
-struct CsharpEmitter<'a, T> {
+struct CSharpEmitter<'a, T> {
     /// Writer.
     out: IndentedWriter<T>,
     /// Generator.
@@ -60,7 +60,7 @@ impl<'a> CodeGenerator<'a> {
 
     /// Output class definitions for `registry` in separate source files.
     /// Source files will be created in a subdirectory of `install_dir` corresponding to the given
-    /// package name (if any, otherwise `install_dir` it self).
+    /// package name (if any, otherwise `install_dir` itself).
     pub fn write_source_files(
         &self,
         install_dir: std::path::PathBuf,
@@ -116,7 +116,7 @@ impl<'a> CodeGenerator<'a> {
         format: &ContainerFormat,
     ) -> Result<()> {
         let mut file = std::fs::File::create(dir_path.join(name.to_string() + ".cs"))?;
-        let mut emitter = CsharpEmitter {
+        let mut emitter = CSharpEmitter {
             out: IndentedWriter::new(&mut file, IndentConfig::Space(4)),
             generator: self,
             current_namespace,
@@ -140,7 +140,7 @@ impl<'a> CodeGenerator<'a> {
         registry: &Registry,
     ) -> Result<()> {
         let mut file = std::fs::File::create(dir_path.join("TraitHelpers.cs"))?;
-        let mut emitter = CsharpEmitter {
+        let mut emitter = CSharpEmitter {
             out: IndentedWriter::new(&mut file, IndentConfig::Space(4)),
             generator: self,
             current_namespace,
@@ -157,7 +157,7 @@ impl<'a> CodeGenerator<'a> {
     }
 }
 
-impl<'a, T> CsharpEmitter<'a, T>
+impl<'a, T> CSharpEmitter<'a, T>
 where
     T: Write,
 {
@@ -260,7 +260,7 @@ using System.Numerics;"
         use Format::*;
         match format {
             TypeName(x) => self.quote_qualified_name(x),
-            Unit => "Unit".into(),
+            Unit => "Serde.Unit".into(),
             Bool => "bool".into(),
             I8 => "sbyte".into(),
             I16 => "short".into(),
@@ -276,12 +276,12 @@ using System.Numerics;"
             F64 => "double".into(),
             Char => "char".into(),
             Str => "string".into(),
-            Bytes => "ValueArray<byte>".into(),
+            Bytes => "Serde.ValueArray<byte>".into(),
 
-            Option(format) => format!("Option<{}>", self.quote_type(format)),
-            Seq(format) => format!("ValueArray<{}>", self.quote_type(format)),
+            Option(format) => format!("Serde.Option<{}>", self.quote_type(format)),
+            Seq(format) => format!("Serde.ValueArray<{}>", self.quote_type(format)),
             Map { key, value } => format!(
-                "ValueDictionary<{}, {}>",
+                "Serde.ValueDictionary<{}, {}>",
                 self.quote_type(key),
                 self.quote_type(value)
             ),
@@ -289,7 +289,7 @@ using System.Numerics;"
             TupleArray {
                 content,
                 size: _size,
-            } => format!("ValueArray<{}>", self.quote_type(content),),
+            } => format!("Serde.ValueArray<{}>", self.quote_type(content),),
             Variable(_) => panic!("unexpected value"),
         }
     }
@@ -431,7 +431,7 @@ using System.Numerics;"
 
         write!(
             self.out,
-            "public static void serialize_{}({} value, ISerializer serializer) {{",
+            "public static void serialize_{}({} value, Serde.ISerializer serializer) {{",
             name,
             self.quote_type(format0)
         )?;
@@ -499,7 +499,7 @@ serializer.sort_map_entries(offsets);
                     self.out,
                     r#"
 if (value.Count != {0}) {{
-    throw new SerializationException("Invalid length for fixed-size array: " + value.Count + " instead of " + {0});
+    throw new Serde.SerializationException("Invalid length for fixed-size array: " + value.Count + " instead of " + {0});
 }}
 foreach (var item in value) {{
     {1}
@@ -521,7 +521,7 @@ foreach (var item in value) {{
 
         write!(
             self.out,
-            "public static {} deserialize_{}(IDeserializer deserializer) {{",
+            "public static {} deserialize_{}(Serde.IDeserializer deserializer) {{",
             self.quote_type(format0),
             name,
         )?;
@@ -533,9 +533,9 @@ foreach (var item in value) {{
                     r#"
 bool tag = deserializer.deserialize_option_tag();
 if (!tag) {{
-    return Option<{0}>.None;
+    return Serde.Option<{0}>.None;
 }} else {{
-    return Option<{0}>.Some({1});
+    return Serde.Option<{0}>.Some({1});
 }}
 "#,
                     self.quote_type(format),
@@ -552,7 +552,7 @@ long length = deserializer.deserialize_len();
 for (int i = 0; i < length; i++) {{
     obj[i] = {1};
 }}
-return new ValueArray<{0}>(obj);
+return new Serde.ValueArray<{0}>(obj);
 "#,
                     self.quote_type(format),
                     self.quote_deserialize(format)
@@ -573,15 +573,15 @@ for (long i = 0; i < length; i++) {{
     int key_end = deserializer.get_buffer_offset();
     if (i > 0) {{
         deserializer.check_that_key_slices_are_increasing(
-            new Range(previous_key_start, previous_key_end),
-            new Range(key_start, key_end));
+            new Serde.Range(previous_key_start, previous_key_end),
+            new Serde.Range(key_start, key_end));
     }}
     previous_key_start = key_start;
     previous_key_end = key_end;
     var value = {3};
     obj[key] = value;
 }}
-return new ValueDictionary<{0}, {1}>(obj);
+return new Serde.ValueDictionary<{0}, {1}>(obj);
 "#,
                     self.quote_type(key),
                     self.quote_type(value),
@@ -613,7 +613,7 @@ return ({}
 for (int i = 0; i < {1}; i++) {{
     obj[i] = {2};
 }}
-return new ValueArray<{0}>(obj);
+return new Serde.ValueArray<{0}>(obj);
 "#,
                     self.quote_type(content),
                     size,
@@ -635,17 +635,18 @@ return new ValueArray<{0}>(obj);
         variant: &VariantFormat,
     ) -> Result<()> {
         use VariantFormat::*;
+        // Using small-caps field names to avoid collisions with class names.
         let fields = match variant {
             Unit => Vec::new(),
             NewType(format) => vec![Named {
-                name: "Value".to_string(),
+                name: "value".to_string(),
                 value: format.as_ref().clone(),
             }],
             Tuple(formats) => formats
                 .iter()
                 .enumerate()
                 .map(|(i, f)| Named {
-                    name: format!("Field{}", i),
+                    name: format!("field{}", i),
                     value: f.clone(),
                 })
                 .collect(),
@@ -735,7 +736,7 @@ return new ValueArray<{0}>(obj);
         if self.generator.config.serialization {
             writeln!(
                 self.out,
-                "\npublic {}void Serialize(ISerializer serializer) {{",
+                "\npublic {}void Serialize(Serde.ISerializer serializer) {{",
                 fn_mods
             )?;
             self.out.indent();
@@ -765,13 +766,13 @@ return new ValueArray<{0}>(obj);
             if variant_index.is_none() {
                 writeln!(
                     self.out,
-                    "\npublic static {}{} Deserialize(IDeserializer deserializer) {{",
+                    "\npublic static {}{} Deserialize(Serde.IDeserializer deserializer) {{",
                     fn_mods, name,
                 )?;
             } else {
                 writeln!(
                     self.out,
-                    "\ninternal static {} Load(IDeserializer deserializer) {{",
+                    "\ninternal static {} Load(Serde.IDeserializer deserializer) {{",
                     name,
                 )?;
             }
@@ -874,11 +875,11 @@ return new ValueArray<{0}>(obj);
         if self.generator.config.serialization {
             writeln!(
                 self.out,
-                "\npublic abstract void Serialize(ISerializer serializer);"
+                "\npublic abstract void Serialize(Serde.ISerializer serializer);"
             )?;
             write!(
                 self.out,
-                "\npublic static {} Deserialize(IDeserializer deserializer) {{",
+                "\npublic static {} Deserialize(Serde.IDeserializer deserializer) {{",
                 name
             )?;
             self.out.indent();
@@ -898,7 +899,7 @@ switch (index) {{"#,
             }
             writeln!(
                 self.out,
-                r#"default: throw new DeserializationException("Unknown variant index for {}: " + index);"#,
+                r#"default: throw new Serde.DeserializationException("Unknown variant index for {}: " + index);"#,
                 name,
             )?;
             self.out.unindent();
@@ -981,17 +982,17 @@ switch (index) {{"#,
             writeln!(
                 self.out,
                 r#"
-public static void Serialize(this {0} value, ISerializer serializer) {{
+public static void Serialize(this {0} value, Serde.ISerializer serializer) {{
     serializer.increase_container_depth();
     serializer.serialize_variant_index((int)value);
     serializer.decrease_container_depth();
 }}
 
-public static {0} Deserialize(IDeserializer deserializer) {{
+public static {0} Deserialize(Serde.IDeserializer deserializer) {{
     deserializer.increase_container_depth();
     int index = deserializer.deserialize_variant_index();
     if (!Enum.IsDefined(typeof({0}), index))
-        throw new DeserializationException("Unknown variant index for {}: " + index);
+        throw new Serde.DeserializationException("Unknown variant index for {}: " + index);
     {0} value = ({0})index;
     deserializer.decrease_container_depth();
     return value;
@@ -1004,7 +1005,7 @@ public static {0} Deserialize(IDeserializer deserializer) {{
                     self.out,
                     r#"
 public static byte[] {0}Serialize(this {1} value)  {{
-    ISerializer serializer = new {0}.{0}Serializer();
+    Serde.ISerializer serializer = new Serde.{0}.{0}Serializer();
     Serialize(value, serializer);
     return serializer.get_bytes();
 }}"#,
@@ -1028,13 +1029,13 @@ public static byte[] {0}Serialize(this {1} value)  {{
 public int {0}Serialize(byte[] outputBuffer) => {0}Serialize(new ArraySegment<byte>(outputBuffer));
 
 public int {0}Serialize(ArraySegment<byte> outputBuffer) {{
-    ISerializer serializer = new {0}.{0}Serializer(outputBuffer);
+    Serde.ISerializer serializer = new Serde.{0}.{0}Serializer(outputBuffer);
     Serialize(serializer);
     return serializer.get_buffer_offset();
 }}
 
 public byte[] {0}Serialize()  {{
-    ISerializer serializer = new {0}.{0}Serializer();
+    Serde.ISerializer serializer = new Serde.{0}.{0}Serializer();
     Serialize(serializer);
     return serializer.get_bytes();
 }}"#,
@@ -1054,12 +1055,12 @@ public static {0} {1}Deserialize(byte[] input) => {1}Deserialize(new ArraySegmen
 
 public static {0} {1}Deserialize(ArraySegment<byte> input) {{
     if (input == null) {{
-         throw new DeserializationException("Cannot deserialize null array");
+         throw new Serde.DeserializationException("Cannot deserialize null array");
     }}
-    IDeserializer deserializer = new {1}.{1}Deserializer(input);
+    Serde.IDeserializer deserializer = new Serde.{1}.{1}Deserializer(input);
     {0} value = Deserialize(deserializer);
     if (deserializer.get_buffer_offset() < input.Count) {{
-         throw new DeserializationException("Some input bytes were not read");
+         throw new Serde.DeserializationException("Some input bytes were not read");
     }}
     return value;
 }}"#,
@@ -1070,6 +1071,7 @@ public static {0} {1}Deserialize(ArraySegment<byte> input) {{
 
     fn output_container(&mut self, name: &str, format: &ContainerFormat) -> Result<()> {
         use ContainerFormat::*;
+        // Using small-caps field names 'value' and 'fieldX' to avoid collisions with class names.
         let fields = match format {
             UnitStruct => Vec::new(),
             NewTypeStruct(format) => vec![Named {

--- a/serde-generate/tests/csharp_generation.rs
+++ b/serde-generate/tests/csharp_generation.rs
@@ -21,53 +21,56 @@ fn test_that_csharp_code_compiles_with_config(
     let dir = tempdir().unwrap();
     let dir_path = dir.path().to_path_buf();
 
-    let installer = csharp::Installer::new(dir_path.to_path_buf());
+    let installer = csharp::Installer::new(dir_path.clone());
     installer.install_module(&config, &registry).unwrap();
     installer.install_serde_runtime().unwrap();
     installer.install_bincode_runtime().unwrap();
     installer.install_lcs_runtime().unwrap();
 
+    let project = include_str!("../runtime/csharp/Serde/Serde.csproj");
+    std::fs::write(dir.path().join("Project.csproj"), project).unwrap();
+
     {
         let _lock = MUTEX.lock();
         let status = Command::new("dotnet")
             .arg("build")
-            .current_dir(dir_path.join("Serde"))
+            .current_dir(&dir_path)
             .status()
             .unwrap();
         assert!(status.success());
     }
 
-    (dir, dir_path.join("Serde").join("Generated").to_path_buf())
+    (dir, dir_path.join("Org").join("Generated").to_path_buf())
 }
 
 #[test]
 fn test_that_csharp_code_compiles() {
-    let config = CodeGeneratorConfig::new("Serde.Generated".to_string());
+    let config = CodeGeneratorConfig::new("Org.Generated".to_string());
     test_that_csharp_code_compiles_with_config(&config);
 }
 
 #[test]
 fn test_that_csharp_code_compiles_without_serialization() {
-    let config = CodeGeneratorConfig::new("Serde.Generated".to_string()).with_serialization(false);
+    let config = CodeGeneratorConfig::new("Org.Generated".to_string()).with_serialization(false);
     test_that_csharp_code_compiles_with_config(&config);
 }
 
 #[test]
 fn test_that_csharp_code_compiles_with_c_style_enums() {
-    let config = CodeGeneratorConfig::new("Serde.Generated".to_string()).with_c_style_enums(true);
+    let config = CodeGeneratorConfig::new("Org.Generated".to_string()).with_c_style_enums(true);
     test_that_csharp_code_compiles_with_config(&config);
 }
 
 #[test]
 fn test_that_csharp_code_compiles_with_lcs() {
     let config =
-        CodeGeneratorConfig::new("Serde.Generated".to_string()).with_encodings(vec![Encoding::Lcs]);
+        CodeGeneratorConfig::new("Org.Generated".to_string()).with_encodings(vec![Encoding::Lcs]);
     test_that_csharp_code_compiles_with_config(&config);
 }
 
 #[test]
 fn test_that_csharp_code_compiles_with_bincode() {
-    let config = CodeGeneratorConfig::new("Serde.Generated".to_string())
+    let config = CodeGeneratorConfig::new("Org.Generated".to_string())
         .with_encodings(vec![Encoding::Bincode]);
     test_that_csharp_code_compiles_with_config(&config);
 }
@@ -76,7 +79,7 @@ fn test_that_csharp_code_compiles_with_bincode() {
 fn test_that_csharp_code_compiles_with_comments() {
     let comments = vec![(
         vec![
-            "Serde".to_string(),
+            "Org".to_string(),
             "Generated".to_string(),
             "SerdeData".to_string(),
         ],
@@ -84,7 +87,7 @@ fn test_that_csharp_code_compiles_with_comments() {
     )]
     .into_iter()
     .collect();
-    let config = CodeGeneratorConfig::new("Serde.Generated".to_string()).with_comments(comments);
+    let config = CodeGeneratorConfig::new("Org.Generated".to_string()).with_comments(comments);
 
     let (_dir, path) = test_that_csharp_code_compiles_with_config(&config);
     let content = std::fs::read_to_string(path.join("SerdeData.cs")).unwrap();
@@ -99,7 +102,7 @@ fn test_csharp_code_with_external_definitions() {
     // (wrongly) Declare TraitHelpers as external.
     let mut definitions = BTreeMap::new();
     definitions.insert("foo".to_string(), vec!["TraitHelpers".to_string()]);
-    let config = CodeGeneratorConfig::new("Serde.Generated".to_string())
+    let config = CodeGeneratorConfig::new("Org.Generated".to_string())
         .with_external_definitions(definitions);
     let generator = csharp::CodeGenerator::new(&config);
 
@@ -108,6 +111,6 @@ fn test_csharp_code_with_external_definitions() {
         .unwrap();
 
     // References were updated.
-    let content = std::fs::read_to_string(dir.path().join("Serde/Generated/SerdeData.cs")).unwrap();
+    let content = std::fs::read_to_string(dir.path().join("Org/Generated/SerdeData.cs")).unwrap();
     assert!(content.contains("foo.TraitHelpers."));
 }


### PR DESCRIPTION
## Summary

* Consistently use lowercase autogenerated field names "value" and "fieldX" to avoid breaking compilation in case of a collision with a class name (e.g. variant `Value`). This is also more likely to match the rest of the generated code since serde-reflection extracts lowercase field names from Rust. (@mattico We could also add an option to enforce uppercase public fields everywhere, if needed in the future.)
* Change .csproj file again to remove some warnings on my laptop.
* Support generation of C# files outside of the Serde project

## Test Plan

CI