### PR TITLE
Update binary serde

### DIFF
--- a/serde-generate/runtime/typescript/serde/binaryDeserializer.ts
+++ b/serde-generate/runtime/typescript/serde/binaryDeserializer.ts
@@ -1,9 +1,11 @@
 import { Deserializer } from './deserializer';
+import util from 'util';
 
 export abstract class BinaryDeserializer implements Deserializer {
   private static readonly BIG_32 = BigInt(32);
   private static readonly BIG_64 = BigInt(64);
-  private static readonly textDecoder: TextDecoder = new TextDecoder();
+  private static readonly textDecoder =
+      typeof window === 'undefined' ? new util.TextDecoder() : new TextDecoder();
   public buffer: ArrayBuffer;
   public offset: number;
 
@@ -49,7 +51,7 @@ export abstract class BinaryDeserializer implements Deserializer {
   }
 
   public deserializeUnit(): null {
-    return;
+    return null;
   }
 
   public deserializeU8(): number {

--- a/serde-generate/runtime/typescript/serde/binarySerializer.ts
+++ b/serde-generate/runtime/typescript/serde/binarySerializer.ts
@@ -1,4 +1,5 @@
 import { Serializer } from './serializer';
+import util from 'util';
 
 export abstract class BinarySerializer implements Serializer {
     private static readonly BIG_32 = BigInt(32);
@@ -10,7 +11,8 @@ export abstract class BinarySerializer implements Serializer {
     private static readonly BIG_32Fs = BigInt('4294967295');
     private static readonly BIG_64Fs = BigInt('18446744073709551615');
 
-    private static readonly textEncoder: TextEncoder = new TextEncoder();
+    private static readonly textEncoder =
+        typeof window === 'undefined' ? new util.TextEncoder() : new TextEncoder();
 
     private buffer: ArrayBuffer;
     private offset: number;
@@ -21,12 +23,11 @@ export abstract class BinarySerializer implements Serializer {
     }
 
     private ensureBufferWillHandleSize(bytes: number) {
-        if (this.offset + bytes <= this.buffer.byteLength) {
-            return;
+        while (this.buffer.byteLength < this.offset + bytes) {
+            const newBuffer = new ArrayBuffer(this.buffer.byteLength * 2);
+            new Uint8Array(newBuffer).set(new Uint8Array(this.buffer));
+            this.buffer = newBuffer;
         }
-        const newBuffer = new ArrayBuffer(this.buffer.byteLength * 2);
-        new Uint8Array(newBuffer).set(new Uint8Array(this.buffer));
-        this.buffer = newBuffer;
     }
 
     protected serialize(values: Uint8Array) {


### PR DESCRIPTION
## Summary

- Update typescript runtime to use `util` for `TextEncoder`/`TextDecoder`
- Return null for Unit (instead of undefined)
- Handle more than double space needed for a new byte array insert (`ensureBufferWillHandleSize`)


## Test Plan

no change
