### PR TITLE
Update class lib TargetFramework .NET project attr to current default

### DIFF
--- a/serde-generate/runtime/csharp/Bcs/Bcs.csproj
+++ b/serde-generate/runtime/csharp/Bcs/Bcs.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-       <TargetFramework>netstandard1.6</TargetFramework>
+       <TargetFramework>netstandard2.0</TargetFramework>
        <LangVersion>7.2</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/serde-generate/runtime/csharp/Bincode/Bincode.csproj
+++ b/serde-generate/runtime/csharp/Bincode/Bincode.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-       <TargetFramework>netstandard1.6</TargetFramework>
+       <TargetFramework>netstandard2.0</TargetFramework>
        <LangVersion>7.2</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/serde-generate/runtime/csharp/Serde/Serde.csproj
+++ b/serde-generate/runtime/csharp/Serde/Serde.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-       <TargetFramework>netstandard1.6</TargetFramework>
+       <TargetFramework>netstandard2.0</TargetFramework>
        <LangVersion>7.2</LangVersion>
     </PropertyGroup>
     <ItemGroup>

--- a/serde-generate/src/csharp.rs
+++ b/serde-generate/src/csharp.rs
@@ -1165,7 +1165,7 @@ impl crate::SourceInstaller for Installer {
             r#"
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-       <TargetFramework>netstandard1.6</TargetFramework>
+       <TargetFramework>netstandard2.0</TargetFramework>
        <LangVersion>7.2</LangVersion>
     </PropertyGroup>
     <ItemGroup>


### PR DESCRIPTION
```
Class library (C#)
Author: Microsoft
Description: A project for creating a class library that targets .NET Standard or .NET Core
Options:
  -f|--framework  The target framework for the project.
                      netcoreapp3.1     - Target netcoreapp3.1
                      netstandard2.1    - Target netstandard2.1
                      netstandard2.0    - Target netstandard2.0
                  Default: netstandard2.0
```

## Summary

The current framework default for .NET class libraries is netstandard2.0. Update to reflect that.

## Test Plan

Visual
