### PR TITLE
[serde-generate] release version 0.19.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bcs",
  "bincode",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.18.0"
+version = "0.19.0"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/novifinancial/serde-reflection"

--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -15,7 +15,7 @@ The following target languages are currently supported:
 
 * C++ 17
 * Java 8
-* Python 3
+* Python 3 (requires numpy >= 1.20.1)
 * Rust 2018
 * Go >= 1.14
 * C# (NetCoreApp >= 2.1)

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -10,7 +10,7 @@
 //!
 //! * C++ 17
 //! * Java 8
-//! * Python 3
+//! * Python 3 (requires numpy >= 1.20.1)
 //! * Rust 2018
 //! * Go >= 1.14
 //! * C# (NetCoreApp >= 2.1)


### PR DESCRIPTION
## Summary

* Includes latest config changes for C#
* Python runtime requires numpy >= 1.20.1 for typechecking with Pyre

## Test Plan

CI