### PR TITLE
Typescript external definitions use mod.ts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.20.0"
+version = "0.20.1"
 dependencies = [
  "bcs",
  "bincode",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.20.0"
+version = "0.20.1"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/novifinancial/serde-reflection"

--- a/serde-generate/src/typescript.rs
+++ b/serde-generate/src/typescript.rs
@@ -98,7 +98,7 @@ import {{ Optional, Seq, Tuple, ListTuple, unit, bool, int8, int16, int32, int64
         for namespace in self.generator.namespaces_to_import.iter() {
             writeln!(
                 self.out,
-                "import * as {} from '../{}.ts';\n",
+                "import * as {} from '../{}/mod.ts';\n",
                 namespace.to_camel_case(),
                 namespace
             )?;

--- a/serde-generate/tests/typescript_generation.rs
+++ b/serde-generate/tests/typescript_generation.rs
@@ -3,7 +3,7 @@
 
 use regex::Regex;
 use serde_generate::{test_utils, typescript, CodeGeneratorConfig, Encoding, SourceInstaller};
-use std::{fs::File, path::Path, process::Command};
+use std::{collections::BTreeMap, fs::File, path::Path, process::Command};
 use tempfile::tempdir;
 
 fn test_typescript_code_compiles_with_config(
@@ -96,4 +96,24 @@ fn test_typescript_code_compiles_with_comments() {
  */
 "#
     ));
+}
+
+#[test]
+fn test_typescript_code_compiles_with_external_definitions() {
+    let dir = tempdir().unwrap();
+
+    // create external definition
+    std::fs::create_dir_all(dir.path().join("external")).unwrap_or(());
+    std::fs::write(
+        dir.path().join("external/mod.ts"),
+        "export const CustomType = 5;",
+    )
+    .unwrap();
+
+    let mut external_definitions = BTreeMap::new();
+    external_definitions.insert(String::from("external"), vec![String::from("CustomType")]);
+    let config = CodeGeneratorConfig::new("testing".to_string())
+        .with_external_definitions(external_definitions);
+
+    test_typescript_code_compiles_with_config(&dir.path(), &config);
 }


### PR DESCRIPTION
## Summary

Prior to change, external namespaces were pull in as a single type script file:
```
workspace/diem/shuffle/move/examples/main/txn_builders/diemTypes.ts
```

To better comply with deno conventions, this has been updated to namespace/mod.ts:
```
workspace/diem/shuffle/move/examples/main/txn_builders/diemTypes/mod.ts
```

## Test Plan

`cargo test test_typescript_code_compiles_with_external_definitions`
