### PR TITLE
[serde-generate] Make typescript source installer follow mod.ts convention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.20.1"
+version = "0.20.2"
 dependencies = [
  "bcs",
  "bincode",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.20.1"
+version = "0.20.2"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/novifinancial/serde-reflection"

--- a/serde-generate/src/typescript.rs
+++ b/serde-generate/src/typescript.rs
@@ -714,7 +714,7 @@ impl crate::SourceInstaller for Installer {
     ) -> std::result::Result<(), Self::Error> {
         let dir_path = self.install_dir.join(&config.module_name);
         std::fs::create_dir_all(&dir_path)?;
-        let source_path = dir_path.join("index.ts");
+        let source_path = dir_path.join("mod.ts");
         let mut file = std::fs::File::create(source_path)?;
 
         let generator = CodeGenerator::new(config);

--- a/serde-generate/tests/typescript_runtime.rs
+++ b/serde-generate/tests/typescript_runtime.rs
@@ -11,11 +11,7 @@ use std::{fs::File, io::Write, process::Command};
 use tempfile::tempdir;
 
 #[test]
-fn test_typescript_bcs_runtime_on_simple_data() {
-    test_typescript_runtime_on_simple_data(Runtime::Bcs);
-}
-
-fn test_typescript_runtime_on_simple_data(runtime: Runtime) {
+fn test_typescript_runtime_bcs_serialization() {
     let registry = test_utils::get_simple_registry().unwrap();
     let dir = tempdir().unwrap();
     let dir_path = dir.path();
@@ -28,6 +24,7 @@ fn test_typescript_runtime_on_simple_data(runtime: Runtime) {
     let source_path = dir_path.join("tests/test.ts");
     let mut source = File::create(&source_path).unwrap();
 
+    let runtime = Runtime::Bcs;
     let config = CodeGeneratorConfig::new("main".to_string()).with_encodings(vec![runtime.into()]);
     let generator = typescript::CodeGenerator::new(&config);
     generator.output(&mut source, &registry).unwrap();


### PR DESCRIPTION
## Summary

Previously, custom external code did not abide by mod.ts convention.

Prior:
```
import * as DiemTypes from ../diemTypes/index.ts
```

```
import * as DiemTypes from ../diemTypes/mod.ts
```


## Test Plan

cargo test