### PR TITLE
[dart] make `dart test` work from runtime/dart

### DIFF
--- a/serde-generate/README.md
+++ b/serde-generate/README.md
@@ -26,6 +26,7 @@ The following programming languages are fully supported as target languages:
 The following languages are partially supported and still considered under development:
 
 * TypeScript 4 (packaged and tested with Deno)
+* Dart >= 2
 
 ### Supported Encodings
 

--- a/serde-generate/runtime/dart/pubspec.yaml
+++ b/serde-generate/runtime/dart/pubspec.yaml
@@ -1,0 +1,10 @@
+name: serde
+
+environment:
+  sdk: '>=2.14.0 <3.0.0'
+
+dependencies:
+  meta: ^1.0.0
+  tuple: ^2.0.0
+dev_dependencies: 
+  test: ^1.19.3

--- a/serde-generate/runtime/dart/test/bcs_test.dart
+++ b/serde-generate/runtime/dart/test/bcs_test.dart
@@ -3,7 +3,7 @@
 
 import 'dart:typed_data';
 import 'package:test/test.dart';
-import '../lib/src/bcs/bcs.dart';
+import '../bcs/bcs.dart';
 
 void main() {
   test('serializeUint32', () {

--- a/serde-generate/runtime/dart/test/bincode_test.dart
+++ b/serde-generate/runtime/dart/test/bincode_test.dart
@@ -3,7 +3,7 @@
 
 import 'dart:typed_data';
 import 'package:test/test.dart';
-import '../lib/src/bincode/bincode.dart';
+import '../bincode/bincode.dart';
 
 void main() {
   test('serializeUint32', () {

--- a/serde-generate/runtime/dart/test/serde_test.dart
+++ b/serde-generate/runtime/dart/test/serde_test.dart
@@ -3,7 +3,7 @@
 
 import 'package:test/test.dart';
 
-import '../lib/src/serde/serde.dart';
+import '../serde/serde.dart';
 
 void main() {
   test('Uint64', () {

--- a/serde-generate/src/lib.rs
+++ b/serde-generate/src/lib.rs
@@ -21,6 +21,7 @@
 //! The following languages are partially supported and still considered under development:
 //!
 //! * TypeScript 4 (packaged and tested with Deno)
+//! * Dart >= 2
 //!
 //! ## Supported Encodings
 //!


### PR DESCRIPTION
## Summary

This is me trying to make the basic Dart unit tests runnable from the CLI.

## Test Plan

```
cd serde-generate/runtime/dart
dart test
```
