### PR TITLE
[serde-generate] fix empty struct/tuple variants in python and swift

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,7 +348,7 @@ dependencies = [
 
 [[package]]
 name = "serde-generate"
-version = "0.20.5"
+version = "0.20.6"
 dependencies = [
  "bcs",
  "bincode",

--- a/serde-generate/Cargo.toml
+++ b/serde-generate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serde-generate"
-version = "0.20.5"
+version = "0.20.6"
 description = "Generate (de)serialization code in multiple languages"
 documentation = "https://docs.rs/serde-generate"
 repository = "https://github.com/novifinancial/serde-reflection"

--- a/serde-generate/runtime/python/serde_binary/__init__.py
+++ b/serde-generate/runtime/python/serde_binary/__init__.py
@@ -142,8 +142,9 @@ class BinarySerializer:
                     self.serialize_any(item, item_type)
 
             elif getattr(obj_type, "__origin__") == tuple:  # Tuple
-                for i in range(len(obj)):
-                    self.serialize_any(obj[i], types[i])
+                if len(types) is not 1 or types[0] is not ():
+                    for i in range(len(obj)):
+                        self.serialize_any(obj[i], types[i])
 
             elif getattr(obj_type, "__origin__") == typing.Union:  # Option
                 assert len(types) == 2 and types[1] == type(None)
@@ -347,6 +348,8 @@ class BinaryDeserializer:
 
             elif getattr(obj_type, "__origin__") == tuple:  # Tuple
                 result = []
+                if len(types) is 1 and types[0] is ():
+                    return tuple()
                 for i in range(len(types)):
                     item = self.deserialize_any(types[i])
                     result.append(item)

--- a/serde-generate/src/python3.rs
+++ b/serde-generate/src/python3.rs
@@ -166,7 +166,13 @@ import typing
                 self.quote_type(key),
                 self.quote_type(value)
             ),
-            Tuple(formats) => format!("typing.Tuple[{}]", self.quote_types(formats)),
+            Tuple(formats) => {
+                if formats.is_empty() {
+                    "typing.Tuple[()]".into()
+                } else {
+                    format!("typing.Tuple[{}]", self.quote_types(formats))
+                }
+            }
             TupleArray { content, size } => format!(
                 "typing.Tuple[{}]",
                 self.quote_types(&vec![content.as_ref().clone(); *size])

--- a/serde-generate/src/swift.rs
+++ b/serde-generate/src/swift.rs
@@ -477,19 +477,27 @@ return obj
                 writeln!(self.out, "case {}({})", name, self.quote_type(format))?;
             }
             Tuple(formats) => {
-                writeln!(self.out, "case {}({})", name, self.quote_types(formats))?;
+                if formats.is_empty() {
+                    writeln!(self.out, "case {}", name)?;
+                } else {
+                    writeln!(self.out, "case {}({})", name, self.quote_types(formats))?;
+                }
             }
             Struct(fields) => {
-                writeln!(
-                    self.out,
-                    "case {}({})",
-                    name,
-                    fields
-                        .iter()
-                        .map(|f| format!("{}: {}", f.name, self.quote_type(&f.value)))
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                )?;
+                if fields.is_empty() {
+                    writeln!(self.out, "case {}", name)?;
+                } else {
+                    writeln!(
+                        self.out,
+                        "case {}({})",
+                        name,
+                        fields
+                            .iter()
+                            .map(|f| format!("{}: {}", f.name, self.quote_type(&f.value)))
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )?;
+                }
             }
             Variable(_) => panic!("incorrect value"),
         }

--- a/serde-generate/src/test_utils.rs
+++ b/serde-generate/src/test_utils.rs
@@ -52,6 +52,8 @@ pub enum SerdeData {
     SimpleList(SimpleList),
     CStyleEnum(CStyleEnum),
     ComplexMap(BTreeMap<([u32; 2], [u8; 4]), ()>),
+    EmptyTupleVariant(),
+    EmptyStructVariant {},
 }
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
@@ -293,8 +295,11 @@ pub fn get_sample_values(has_canonical_maps: bool, has_floats: bool) -> Vec<Serd
 
     let v13 = SerdeData::ComplexMap(btreemap! { ([1,2], [3,4,5,6]) => ()});
 
+    let v14 = SerdeData::EmptyTupleVariant();
+    let v15 = SerdeData::EmptyStructVariant {};
+
     vec![
-        v0, v1, v2, v2bis, v2ter, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13,
+        v0, v1, v2, v2bis, v2ter, v3, v4, v5, v6, v7, v8, v9, v10, v11, v12, v13, v14, v15,
     ]
 }
 
@@ -598,7 +603,7 @@ impl Runtime {
 
 #[test]
 fn test_get_sample_values() {
-    assert_eq!(get_sample_values(false, true).len(), 16);
+    assert_eq!(get_sample_values(false, true).len(), 18);
 }
 
 #[test]
@@ -775,6 +780,12 @@ SerdeData:
                     CONTENT: U8
                     SIZE: 4
             VALUE: UNIT
+    13:
+      EmptyTupleVariant:
+        TUPLE: []
+    14:
+      EmptyStructVariant:
+        STRUCT: []
 SimpleList:
   NEWTYPESTRUCT:
     OPTION:
@@ -906,14 +917,14 @@ fn test_get_alternate_sample_with_container_depth(runtime: Runtime) {
 
 #[test]
 fn test_bincode_get_positive_samples() {
-    assert_eq!(test_get_positive_samples(Runtime::Bincode), 16);
+    assert_eq!(test_get_positive_samples(Runtime::Bincode), 18);
 }
 
 #[test]
 // This test requires --release because of deserialization of long (unit) vectors.
 #[cfg(not(debug_assertions))]
 fn test_bcs_get_positive_samples() {
-    assert_eq!(test_get_positive_samples(Runtime::Bcs), 98);
+    assert_eq!(test_get_positive_samples(Runtime::Bcs), 100);
 }
 
 // Make sure all the "positive" samples successfully deserialize with the reference Rust
@@ -937,7 +948,7 @@ fn test_bincode_get_negative_samples() {
 // This test requires --release because of deserialization of long (unit) vectors.
 #[cfg(not(debug_assertions))]
 fn test_bcs_get_negative_samples() {
-    assert_eq!(test_get_negative_samples(Runtime::Bcs), 61);
+    assert_eq!(test_get_negative_samples(Runtime::Bcs), 63);
 }
 
 // Make sure all the "negative" samples fail to deserialize with the reference Rust

--- a/serde-generate/tests/dart_runtime.rs
+++ b/serde-generate/tests/dart_runtime.rs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: MIT OR Apache-2.0
 
 use serde_generate::{dart, test_utils, CodeGeneratorConfig, SourceInstaller};
-use std::fs::{create_dir_all, File};
-use std::{io::Result, io::Write, path::Path, process::Command};
+use std::{
+    fs::{create_dir_all, File},
+    io::{Result, Write},
+    path::Path,
+    process::Command,
+};
 use tempfile::tempdir;
 use test_utils::{Choice, Runtime, Test};
 


### PR DESCRIPTION
## Summary

Support `enum Foo { Bar(), Baz{} }`

## Test Plan

new test cases + CI