### PR TITLE
Dart utf8

### DIFF
--- a/serde-generate/runtime/dart/serde/binary_deserializer.dart
+++ b/serde-generate/runtime/dart/serde/binary_deserializer.dart
@@ -111,7 +111,7 @@ abstract class BinaryDeserializer {
   int deserializeVariantIndex();
 
   String deserializeString() {
-    return String.fromCharCodes(deserializeUint8List());
+    return utf8.decode(deserializeUint8List());
   }
 
   int deserializeLength();

--- a/serde-generate/runtime/dart/serde/binary_serializer.dart
+++ b/serde-generate/runtime/dart/serde/binary_serializer.dart
@@ -123,7 +123,7 @@ abstract class BinarySerializer {
   void serializeVariantIndex(int index);
 
   void serializeString(String str) {
-    serializeUint8List(Uint8List.fromList(str.codeUnits));
+    serializeUint8List(Uint8List.fromList(utf8.encode(str)));
   }
 
   void serializeLength(int len);

--- a/serde-generate/runtime/dart/serde/serde.dart
+++ b/serde-generate/runtime/dart/serde/serde.dart
@@ -3,6 +3,7 @@
 
 library serde;
 
+import 'dart:convert' show utf8;
 import 'dart:typed_data';
 
 import 'package:meta/meta.dart';

--- a/serde-generate/runtime/dart/test/bincode_test.dart
+++ b/serde-generate/runtime/dart/test/bincode_test.dart
@@ -94,4 +94,11 @@ void main() {
     expect(() => serializer.serializeInt32(2147483648), throwsException);
     expect(() => serializer.serializeInt32(-2147483649), throwsException);
   });
+
+  test('serializeString', () {
+    final serializer = BincodeSerializer();
+    serializer.serializeString('dummy text / ダミーテキスト');
+    final deserializer = BincodeDeserializer(serializer.bytes);
+    expect(deserializer.deserializeString(), 'dummy text / ダミーテキスト');
+  });
 }


### PR DESCRIPTION
## Summary

Initial implementation of the Dart runtime handled string ser/de with [utf-16] code units. This had the appearance of working as long as the given character was < 128. This PR switches to utf-8 encode/decode to fix this bug.

## Test Plan

A test is included with Japanese text which causes the current implementation to fail.
